### PR TITLE
GitHub Actions: Add missing pkgbuild to publish_r_macos

### DIFF
--- a/.github/workflows/publish_r_macos.yml
+++ b/.github/workflows/publish_r_macos.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Install roxygen2
       uses: r-lib/actions/setup-r-dependencies@v2
       with:
-        packages: roxygen2
+        packages: roxygen2, pkgbuild
         install-pandoc: false
 
     - name: Install the customized SWIG from source


### PR DESCRIPTION
The `publish_r_macos` workflows recently began to fail: some R versions began to require `pkgbuild`.
This PR adds the missing `pkgbuild`.

Enjoy,
Pierre