### PR TITLE
GitHub Actions: Remove constraints on NumPy version

### DIFF
--- a/.github/workflows/nonreg-demos-courses_ubuntu-latest.yml
+++ b/.github/workflows/nonreg-demos-courses_ubuntu-latest.yml
@@ -25,7 +25,6 @@ env:
   CMAKE_BUILD_TYPE : Release
   BUILD_DIR : build
   PYTHON_VERSION : "3.11"
-  NUMPY_VERSION : "1.23.5"
   R_VERSION : "4.3.2"
   SWIG_ROOT : ${{github.workspace}}/swig_420b
 
@@ -44,7 +43,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install numpy==${{env.NUMPY_VERSION}}
+        python -m pip install numpy
         python -m pip install jupyter
         python -m pip install notebook==6.1.6
         python -m pip install matplotlib

--- a/.github/workflows/nonreg-tests_macos-latest.yml
+++ b/.github/workflows/nonreg-tests_macos-latest.yml
@@ -21,7 +21,6 @@ env:
   CMAKE_BUILD_TYPE : Release
   BUILD_DIR : build
   PYTHON_VERSION : "3.11"
-  NUMPY_VERSION : "1.23.5"
   R_VERSION : "4.3.2"
   SWIG_ROOT : ${{github.workspace}}/swig_420b
 
@@ -40,7 +39,7 @@ jobs:
     - name: Install python dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install numpy==${{env.NUMPY_VERSION}}
+        python -m pip install numpy
 
     - name: Setup R Version
       uses: r-lib/actions/setup-r@v2

--- a/.github/workflows/nonreg-tests_ubuntu-latest.yml
+++ b/.github/workflows/nonreg-tests_ubuntu-latest.yml
@@ -22,7 +22,6 @@ env:
   CMAKE_BUILD_TYPE : Release
   BUILD_DIR : build
   PYTHON_VERSION : "3.11"
-  NUMPY_VERSION : "1.23.5"
   R_VERSION : "4.3.2"
   SWIG_ROOT : ${{github.workspace}}/swig_420b
 
@@ -41,7 +40,7 @@ jobs:
     - name: Install python dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install numpy==${{env.NUMPY_VERSION}}
+        python -m pip install numpy
 
     - name: Setup R Version
       uses: r-lib/actions/setup-r@v2

--- a/.github/workflows/nonreg-tests_windows-latest-msvc.yml
+++ b/.github/workflows/nonreg-tests_windows-latest-msvc.yml
@@ -23,7 +23,6 @@ env:
   BUILD_DIR : build
   CMAKE_GENERATOR : "Visual Studio 17 2022"
   PYTHON_VERSION : "3.11"
-  NUMPY_VERSION : "1.23.5"
   
 jobs:
 
@@ -41,7 +40,7 @@ jobs:
     - name: Install python dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install numpy==${{env.NUMPY_VERSION}}
+        python -m pip install numpy
 
     - name: Configure build directory
       run: |

--- a/.github/workflows/publish_demos.yml
+++ b/.github/workflows/publish_demos.yml
@@ -26,7 +26,6 @@ env:
   CMAKE_BUILD_TYPE: Release
   BUILD_DIR : build
   PYTHON_VERSION : "3.11"
-  NUMPY_VERSION : "1.23.5"
   R_VERSION : "4.3.2"
   SWIG_ROOT : ${{github.workspace}}/swig_420b
 
@@ -48,7 +47,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install numpy==${{env.NUMPY_VERSION}}
+        python -m pip install numpy
         python -m pip install jupyter
         python -m pip install notebook==6.1.6
         python -m pip install matplotlib

--- a/.github/workflows/publish_python_macos.yml
+++ b/.github/workflows/publish_python_macos.yml
@@ -31,14 +31,14 @@ jobs:
     runs-on: ${{matrix.arch.os}}
     strategy:
       matrix:
-        # Python version + Numpy version
+        # Python version
         python: [
           # Double quote for version is needed otherwise 3.10 => 3.1
-            {py: "3.8",  nu: 1.20.3},
-            {py: "3.9",  nu: 1.20.3},
-            {py: "3.10", nu: 1.22.4},
-            {py: "3.11", nu: 1.23.5},
-            {py: "3.12", nu: 1.26.3}
+            {py: "3.8"},
+            {py: "3.9"},
+            {py: "3.10"},
+            {py: "3.11"},
+            {py: "3.12"}
           ]
         arch: [
             {ar: x86_64, os: macos-12, pat: /usr/local},
@@ -66,7 +66,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install numpy==${{matrix.python.nu}} twine build
+        python -m pip install numpy twine build
 
     - name : Configure build directory
       run : |

--- a/.github/workflows/publish_python_ubuntu.yml
+++ b/.github/workflows/publish_python_ubuntu.yml
@@ -32,14 +32,14 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        # Python version + Numpy version
+        # Python version
         python: [
           # Double quote for version is needed otherwise 3.10 => 3.1
-            {py: "3.8",  nu: 1.20.3},
-            {py: "3.9",  nu: 1.20.3},
-            {py: "3.10", nu: 1.22.4},
-            {py: "3.11", nu: 1.23.5},
-            {py: "3.12", nu: 1.26.3}
+            {py: "3.8"},
+            {py: "3.9"},
+            {py: "3.10"},
+            {py: "3.11"},
+            {py: "3.12"}
           ]
         # Only one old Linux and a generic platform name BUILD_PLAT
         os: [ubuntu-20.04]
@@ -62,7 +62,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install numpy==${{matrix.python.nu}}
+        python -m pip install numpy
         python -m pip install build
 
     - name : Configure build directory

--- a/.github/workflows/publish_python_windows.yml
+++ b/.github/workflows/publish_python_windows.yml
@@ -34,14 +34,14 @@ jobs:
     runs-on: windows-2019
     strategy:
       matrix:
-        # Python version + Numpy version
+        # Python version
         python: [
           # Double quote for version is needed otherwise 3.10 => 3.1
-            {py: "3.8",  nu: 1.20.3},
-            {py: "3.9",  nu: 1.20.3},
-            {py: "3.10", nu: 1.22.4},
-            {py: "3.11", nu: 1.23.5},
-            {py: "3.12", nu: 1.26.3}
+            {py: "3.8"},
+            {py: "3.9"},
+            {py: "3.10"},
+            {py: "3.11"},
+            {py: "3.12"}
           ]
         arch: [
             {pl: win_amd64, ar: x64, of: x64},
@@ -61,7 +61,7 @@ jobs:
       # Force specific old version for Numpy
       run: |
         python -m pip install --upgrade pip
-        python -m pip install numpy==${{matrix.python.nu}} twine build
+        python -m pip install numpy twine build
 
     - name: Install Doxygen under windows
       uses: fabien-ors/install-doxygen-windows-action@v1


### PR DESCRIPTION
This PR removes the constraint on the NumPy version in the GitHub Actions workflows. Now, the latest available version should be tested.

Pierre