### PR TITLE
Replace int with Id set to long long

### DIFF
--- a/include/VectorNumT.hpp
+++ b/include/VectorNumT.hpp
@@ -30,7 +30,7 @@ public:
 public:
   inline VectorNumT()                                              : Parent() { }
   inline VectorNumT(const Vector& vec)                             : Parent(vec) { }
-  inline VectorNumT(size_type count, const T& value = T())         : Parent(count, value) { }
+  inline VectorNumT(size_type count, const T& value = {})          : Parent(count, value) { }
   template< class InputIt >
   inline VectorNumT(InputIt first, InputIt last)                   : Parent(first, last) { }
   inline VectorNumT(const VectorNumT& other) = default;
@@ -210,7 +210,7 @@ std::ostream& operator<<(std::ostream& os,
                          const VectorT<VectorNumT<T>>& vec)
 {
   os << "[";
-  for (int i = 0, n = (int)vec.size(); i < n; i++)
+  for (Id i = 0, n = (Id)vec.size(); i < n; i++)
   {
     os << vec.at(i).toString();
     if (i != n - 1) os << " ";
@@ -220,7 +220,7 @@ std::ostream& operator<<(std::ostream& os,
 }
 #endif
 
-typedef VectorNumT<int>       VectorInt;
+typedef VectorNumT<Id>        VectorInt;
 typedef VectorNumT<double>    VectorDouble;
 typedef VectorT<VectorInt>    VectorVectorInt;
 typedef VectorT<VectorDouble> VectorVectorDouble;

--- a/include/VectorT.hpp
+++ b/include/VectorT.hpp
@@ -29,7 +29,7 @@ public:
 public:
   inline VectorT()                                                    : _v(std::make_shared<Vector>()) { }
   inline VectorT(const Vector& vec)                                   : _v(std::make_shared<Vector>(vec)) { }
-  inline VectorT(size_type count, const T& value = T())               : _v(std::make_shared<Vector>(count, value)) { }
+  inline VectorT(size_type count, const T& value = {})                : _v(std::make_shared<Vector>(count, value)) { }
   template< class InputIt >
   inline VectorT(InputIt first, InputIt last)                         : _v(std::make_shared<Vector>()) { _v->assign(first, last); }
   inline VectorT(const VectorT& other) = default;
@@ -61,9 +61,9 @@ public:
   inline bool operator>=(const VectorT& other) const                  { return *_v >= *other._v; }
 
   // For SWIG users (size_type is not much appreciated)
-  inline const T& getAt(int pos) const;
-  inline void setAt(int pos, const T& v);
-  inline int length() const;
+  inline const T& getAt(Id pos) const;
+  inline void setAt(Id pos, const T& v);
+  inline Id length() const;
 
 #ifndef SWIG
   inline const T& at(size_type pos) const;
@@ -145,7 +145,7 @@ private:
 };
 
 template <typename T>
-const T& VectorT<T>::getAt(int pos) const
+const T& VectorT<T>::getAt(Id pos) const
 {
   if (pos < 0 || pos >= length())
     throw("VectorT<T>::get: index out of range");
@@ -153,7 +153,7 @@ const T& VectorT<T>::getAt(int pos) const
 }
 
 template <typename T>
-void VectorT<T>::setAt(int pos, const T& v)
+void VectorT<T>::setAt(Id pos, const T& v)
 {
   if (pos < 0 || pos >= length())
     throw("VectorT<T>::set: index out of range");
@@ -161,9 +161,9 @@ void VectorT<T>::setAt(int pos, const T& v)
   operator[](pos) = v;
 }
 template <typename T>
-int VectorT<T>::length() const
+Id VectorT<T>::length() const
 {
-  return static_cast<int>(_v->size());
+  return static_cast<Id>(_v->size());
 }
 
 template <typename T>

--- a/include/args.hpp
+++ b/include/args.hpp
@@ -17,11 +17,11 @@ public:
   void deactivateDisplay() { _display = false; }                                               //   OK        OK
   
 //                                                                                     //   R         Python
-  int testInt(int a);                                                                  //   OK        OK
-  const int& testIntRef(const int& a);                                                 //   OK        OK
-  const int* testIntPtr(const int* a);                                                 //   ## NOK    OK
-  void testIntRefOut(int& a) const;                                                    //   ## NOK    ## NOK
-  void testIntRefDef(const int& a = 2, const int& b = 3);                              //   OK        OK
+  Id testInt(Id a);                                                                    //   OK        OK
+  const Id& testIntRef(const Id& a);                                                   //   OK        OK
+  const Id* testIntPtr(const Id* a);                                                   //   ## NOK    OK
+  void testIntRefOut(Id& a) const;                                                     //   ## NOK    ## NOK
+  void testIntRefDef(const Id& a = 2, const Id& b = 3);                                //   OK        OK
 
   VectorInt testVectorInt(VectorInt a);                                                //   OK        OK
   const VectorInt& testVectorIntRef(const VectorInt& a);                               //   OK        OK
@@ -76,7 +76,7 @@ public:
                               const VectorString& b =
                                     VectorString({"Str6","Str7"}));
 
-  void testIntOverload(int a) const;                                                   //   ## NOK    OK
+  void testIntOverload(Id a) const;                                                    //   ## NOK    OK
   void testIntOverload(const VectorInt& a) const;                                      //   ## NOK    OK
   void testDoubleOverload(double a) const;                                             //   ## NOK    OK
   void testDoubleOverload(const VectorDouble& a) const;                                //   ## NOK    OK
@@ -85,7 +85,7 @@ public:
 
 private:
   bool               _display;
-  int                _varInt;
+  Id                 _varInt;
   double             _varDouble;
   String             _varString;
   VectorInt          _varVectorInt;

--- a/include/fibo.hpp
+++ b/include/fibo.hpp
@@ -4,8 +4,8 @@
 #include "swigex_define.hpp"
 #include "VectorNumT.hpp"
 
-SWIGEX_EXPORT int fibn(int n);
-SWIGEX_EXPORT VectorInt fib(int n);
+SWIGEX_EXPORT Id fibn(Id n);
+SWIGEX_EXPORT VectorInt fib(Id n);
 
 /**
  * Class which handles Fibonacci integers list
@@ -13,7 +13,7 @@ SWIGEX_EXPORT VectorInt fib(int n);
 class SWIGEX_EXPORT Fibo
 {
   public:
-    Fibo(int n, const String& title = "");
+    Fibo(Id n, const String& title = "");
     virtual ~Fibo();
 
     void resetFromFiboVal(Fibo fib);
@@ -25,7 +25,7 @@ class SWIGEX_EXPORT Fibo
     String getTitle() const;
 
   protected:
-    int    _n;     ///< Maximum integer of the Fibonacci list
+    Id     _n;     ///< Maximum integer of the Fibonacci list
     String _title; ///< Title to be shown when displaying the list
 };
 

--- a/include/swigex_define.hpp
+++ b/include/swigex_define.hpp
@@ -4,7 +4,9 @@
 #include <iostream>
 #include <cmath>
 #include <math.h>
+
 typedef std::string String;
+using Id = long long;
 
 #define DEFAULT_TITLE "Fibonacci List"
 
@@ -16,12 +18,12 @@ typedef std::string String;
 
 template <typename T> inline T getNA();
 template <> inline double getNA() { return DOUBLE_NA; }
-template <> inline int    getNA() { return INT_NA; }
+template <> inline Id     getNA() { return INT_NA; }
 template <> inline String getNA() { return STRING_NA; }
 
 template <typename T> inline bool isNA(const T& v);
 template <> inline bool isNA(const double& v) { return (v == getNA<double>() || std::isnan(v) || std::isinf(v)); }
-template <> inline bool isNA(const int& v)    { return (v == getNA<int>()); }
+template <> inline bool isNA(const Id& v)     { return (v == getNA<Id>()); }
 template <> inline bool isNA(const String& v) { return (v == getNA<String>()); }
 
 #endif // SWIG

--- a/python/pyswigex.i
+++ b/python/pyswigex.i
@@ -84,23 +84,20 @@
 
   template <typename Type> int convertToCpp(PyObject* obj, Type& value);
   
-  template <> int convertToCpp(PyObject* obj, int& value)
+  template <> int convertToCpp(PyObject* obj, Id& value)
   {
     // Test argument
     if (obj == NULL) return SWIG_TypeError;
 
-    long long v = 0; // Biggest integer type whatever the platform
-    int myres = SWIG_AsVal_long_SS_long(obj, &v);
-    //std::cout << "convertToCpp(int): v=" << v << std::endl;
+    int myres = SWIG_AsVal_long_SS_long(obj, &value);
+    //std::cout << "convertToCpp(int): value=" << value << std::endl;
     if (SWIG_IsOK(myres) || myres == SWIG_OverflowError)
     {
-      if (myres == SWIG_OverflowError || v == NPY_INT_NA) // NaN, Inf or out of bound value becomes NA
+      if (myres == SWIG_OverflowError || value == NPY_INT_NA) // NaN, Inf or out of bound value becomes NA
       {
-        myres = SWIG_OK;
-        value = getNA<int>();
+        value = getNA<Id>();
       }
-      else
-        myres = SWIG_AsVal_int(obj, &value);
+      myres = SWIG_OK;
     }
     return myres;
   }
@@ -228,27 +225,27 @@
 %fragment("FromCpp", "header")
 {
   template <typename Type> NPY_TYPES numpyType();
-  template <> NPY_TYPES numpyType<int>()    { return NPY_INT_TYPE; }
+  template <> NPY_TYPES numpyType<Id>()     { return NPY_INT_TYPE; }
   template <> NPY_TYPES numpyType<double>() { return NPY_DOUBLE; }
   template <> NPY_TYPES numpyType<String>() { return NPY_STRING; }
   
   template<typename Type> struct TypeHelper;
-  template <> struct TypeHelper<int>    { static bool hasFixedSize() { return true; } };
+  template <> struct TypeHelper<Id>     { static bool hasFixedSize() { return true; } };
   template <> struct TypeHelper<double> { static bool hasFixedSize() { return true; } };
   template <> struct TypeHelper<String> { static bool hasFixedSize() { return false; } };
   template <typename Type> bool hasFixedSize() { return TypeHelper<Type>::hasFixedSize(); }
   
   template <typename InputType> struct OutTraits;
-  template <> struct OutTraits<int>     { using OutputType = NPY_INT_OUT_TYPE; };
+  template <> struct OutTraits<Id>      { using OutputType = NPY_INT_OUT_TYPE; };
   template <> struct OutTraits<double>  { using OutputType = double; };
   template <> struct OutTraits<String>  { using OutputType = const char*; };
   
   template <typename Type> typename OutTraits<Type>::OutputType convertFromCpp(const Type& value);
-  template <> NPY_INT_OUT_TYPE convertFromCpp(const int& value)
+  template <> NPY_INT_OUT_TYPE convertFromCpp(const Id& value)
   {
     //std::cout << "convertFromCpp(int): value=" << value << std::endl;
     NPY_INT_OUT_TYPE vres = static_cast<NPY_INT_OUT_TYPE>(value);
-    if (isNA<int>(value))
+    if (isNA<Id>(value))
       vres = NPY_INT_NA;
     return vres;
   }
@@ -266,7 +263,7 @@
   }
   
   template <typename Type> PyObject* objectFromCpp(const Type& value);
-  template <> PyObject* objectFromCpp(const int& value)
+  template <> PyObject* objectFromCpp(const Id& value)
   {
     return PyLong_FromLongLong(convertFromCpp(value));
   }

--- a/r/rswigex.i
+++ b/r/rswigex.i
@@ -23,7 +23,7 @@
 {
   template <typename Type> int convertToCpp(SEXP obj, Type& value);
   
-  template <> int convertToCpp(SEXP obj, int& value)
+  template <> int convertToCpp(SEXP obj, Id& value)
   {
     // Test argument
     if (obj == NULL) return SWIG_TypeError;
@@ -31,10 +31,10 @@
     int myres = SWIG_TypeError;
     if (Rf_length(obj) > 0) // Prevent NULL value from becoming NA
     {
-      myres = SWIG_AsVal_int(obj, &value);
+      myres = SWIG_AsVal_long_SS_long(obj, &value);
       //std::cout << "convertToCpp(int): value=" << value << std::endl;
       if (SWIG_IsOK(myres) && value == R_NaInt) // NA, NaN, Inf or out of bounds value becomes NA
-        value = getNA<int>();
+        value = getNA<Id>();
     }
     return myres;
   }
@@ -153,7 +153,7 @@
 }
 
 // Add typecheck typemaps for dispatching functions
-%typemap(rtypecheck, noblock=1) const int&, int                               { length($arg) == 1 && (is.integer(unlist($arg)) || is.numeric(unlist($arg))) }
+%typemap(rtypecheck, noblock=1) const Id&, Id                                 { length($arg) == 1 && (is.integer(unlist($arg)) || is.numeric(unlist($arg))) }
 %typemap(rtypecheck, noblock=1) const double&, double                         { length($arg) == 1 &&  is.numeric(unlist($arg)) }
 %typemap(rtypecheck, noblock=1) const String&, String                         { length($arg) == 1 &&  is.character(unlist($arg)) }
 %typemap(rtypecheck, noblock=1) const VectorInt&, VectorInt                   { length($arg) == 0 || (length($arg) > 0 && (is.integer(unlist($arg)) || is.numeric(unlist($arg)))) }
@@ -167,15 +167,15 @@
 %fragment("FromCpp", "header")
 {  
   template <typename InputType> struct OutTraits;
-  template <> struct OutTraits<int>     { using OutputType = int; };
+  template <> struct OutTraits<Id>      { using OutputType = Id; };
   template <> struct OutTraits<double>  { using OutputType = double; };
   template <> struct OutTraits<String>  { using OutputType = String; };
   
   template <typename Type> typename OutTraits<Type>::OutputType convertFromCpp(const Type& value);
-  template <> int convertFromCpp(const int& value)
+  template <> Id convertFromCpp(const Id& value)
   {
     //std::cout << "convertFromCpp(int): value=" << value << std::endl;
-    if (isNA<int>(value))
+    if (isNA<Id>(value))
       return R_NaInt;
     return value;
   }
@@ -193,7 +193,7 @@
   }
   
   template <typename Type> SEXP objectFromCpp(const Type& value);
-  template <> SEXP objectFromCpp(const int& value)
+  template <> SEXP objectFromCpp(const Id& value)
   {
     return Rf_ScalarInteger(convertFromCpp(value));
   }
@@ -326,14 +326,14 @@ function(x, i, value)
   x
 }
 
-setMethod('[',    '_p_VectorTT_int_t',                  getVitem)
-setMethod('[<-',  '_p_VectorTT_int_t',                  setVitem)
+setMethod('[',    '_p_VectorTT_long_long_t',            getVitem)
+setMethod('[<-',  '_p_VectorTT_long_long_t',            setVitem)
 setMethod('[',    '_p_VectorTT_double_t',               getVitem)
 setMethod('[<-',  '_p_VectorTT_double_t',               setVitem)
 setMethod('[',    '_p_VectorTT_String_t',               getVitem)
 setMethod('[<-',  '_p_VectorTT_String_t',               setVitem)
-setMethod('[',    '_p_VectorNumTT_int_t',               getVitem)
-setMethod('[<-',  '_p_VectorNumTT_int_t',               setVitem)
+setMethod('[',    '_p_VectorNumTT_long_long_t',         getVitem)
+setMethod('[<-',  '_p_VectorNumTT_long_long_t',         setVitem)
 setMethod('[',    '_p_VectorNumTT_double_t',            getVitem)
 setMethod('[<-',  '_p_VectorNumTT_double_t',            setVitem)
 setMethod('[[',   '_p_VectorTT_VectorInt_t',            getVitem)

--- a/src/args.cpp
+++ b/src/args.cpp
@@ -20,34 +20,34 @@ TypeClass::~TypeClass()
 
 }
 
-int TypeClass::testInt(int a)
+Id TypeClass::testInt(Id a)
 {
   _varInt = a;
   if (_display) std::cout << "Test int: " << a << std::endl;
   return _varInt;
 }
 
-const int& TypeClass::testIntRef(const int& a)
+const Id& TypeClass::testIntRef(const Id& a)
 {
   _varInt = a;
   if (_display) std::cout << "Test int Reference: " << a << std::endl;
   return _varInt;
 }
 
-const int* TypeClass::testIntPtr(const int* a)
+const Id* TypeClass::testIntPtr(const Id* a)
 {
   _varInt = *a;
   if (_display) std::cout << "Test int Pointer: " << *a << std::endl;
   return &_varInt;
 }
 
-void TypeClass::testIntRefOut(int& a) const
+void TypeClass::testIntRefOut(Id& a) const
 {
   a = _varInt;
   if (_display) std::cout << "Test int Reference Out: " << a << std::endl;
 }
 
-void TypeClass::testIntRefDef(const int& a, const int& b)
+void TypeClass::testIntRefDef(const Id& a, const Id& b)
 {
   _varInt = a;
   if (_display) std::cout << "Test int Reference Def: " << a << " - " << b << std::endl;
@@ -284,7 +284,7 @@ void TypeClass::testVectorStringRefDef(const VectorString& a, const VectorString
   if (_display) std::cout << "Test VectorString Reference Def: " << a << " - " << b << std::endl;
 }
 
-void TypeClass::testIntOverload(int a) const
+void TypeClass::testIntOverload(Id a) const
 {
   std::cout << "Test int Overload [Scalar]: " << a << std::endl;
 }

--- a/src/fibo.cpp
+++ b/src/fibo.cpp
@@ -11,7 +11,7 @@
  *
  * @param n: index of the value
  */
-int fibn(int n)
+Id fibn(Id n)
 {
   if (n <= 0 || n == INT_NA)
   {
@@ -19,13 +19,13 @@ int fibn(int n)
               << std::endl;
     return -1;
   }
-  int a = 0;
-  int b = 1;
-  int i = 1;
+  Id a = 0;
+  Id b = 1;
+  Id i = 1;
   while (true)
   {
     if (i == n) return a;
-    int aa = a;
+    Id aa = a;
     a      = b;
     b      = aa + b;
     i++;
@@ -41,7 +41,7 @@ int fibn(int n)
  *
  * @param n: maximum value to be generated
  */
-VectorInt fib(int n)
+VectorInt fib(Id n)
 {
   VectorInt res;
   if (n <= 0 || n == INT_NA)
@@ -50,12 +50,12 @@ VectorInt fib(int n)
               << std::endl;
     return res;
   }
-  int a = 0;
-  int b = 1;
+  Id a = 0;
+  Id b = 1;
   while (a < n)
   {
     res.push_back(a);
-    int aa = a;
+    Id aa = a;
     a      = b;
     b      = aa + b;
   }
@@ -68,7 +68,7 @@ VectorInt fib(int n)
  * @param n     Strict positive Integer
  * @param title Title to be printed (optional)
  */
-Fibo::Fibo(int n, const String& title)
+Fibo::Fibo(Id n, const String& title)
   : _n(n)
   , _title(title)
 {

--- a/swig/swig_exp.i
+++ b/swig/swig_exp.i
@@ -12,10 +12,10 @@
 // Export VectorXXX classes
 %include VectorT.hpp
 %include VectorNumT.hpp
-%template(VectorTInt)         VectorT< int >;
+%template(VectorTInt)         VectorT< long long >;
 %template(VectorTDouble)      VectorT< double >;
 %template(VectorString)       VectorT< String >;
-%template(VectorInt)          VectorNumT< int >;
+%template(VectorInt)          VectorNumT< long long >;
 %template(VectorDouble)       VectorNumT< double >;
 %template(VectorVectorInt)    VectorT< VectorInt >;
 %template(VectorVectorDouble) VectorT< VectorDouble >;

--- a/swig/swig_inc.i
+++ b/swig/swig_inc.i
@@ -19,9 +19,13 @@
 %include std_vector.i
 %include std_string.i
 %template(DoNotUseVectorIntStd)     std::vector< int >;
+%template(DoNotUseVectorLongStd)    std::vector< long >;
+%template(DoNotUseVectorLLongStd)   std::vector< long long >;
 %template(DoNotUseVectorDoubleStd)  std::vector< double >;
 %template(DoNotUseVectorStringStd)  std::vector< std::string >; // Keep std::string here otherwise asptr fails!
 %template(DoNotUseVVectorIntStd)    std::vector< std::vector< int > >;
+%template(DoNotUseVVectorLongStd)   std::vector< std::vector< long > >;
+%template(DoNotUseVVectorLLongStd)  std::vector< std::vector< long long > >;
 %template(DoNotUseVVectorDoubleStd) std::vector< std::vector< double > >;
 
 ////////////////////////////////////////////////
@@ -32,7 +36,7 @@
 //          functions must be defined in ToCpp fragment
 
 // Convert scalar arguments by value
-%typemap(in, fragment="ToCpp") int,
+%typemap(in, fragment="ToCpp") Id,
                                double,
                                String
 {
@@ -50,8 +54,8 @@
 
 // Convert scalar argument by reference
 // Don't add String or char here otherwise "res2 not declared" / "alloc1 not declared"
-%typemap(in, fragment="ToCpp") int*       (int val), const int*       (int val),
-                               int&       (int val), const int&       (int val),
+%typemap(in, fragment="ToCpp") Id*     (Id val),     const Id*     (Id val),
+                               Id&     (Id val),     const Id&     (Id val),
                                double* (double val), const double* (double val),
                                double& (double val), const double& (double val)
 {
@@ -198,14 +202,14 @@
 //        - vectorFromCpp, vectorVectorFromCpp and objectFromCpp 
 //          functions must be defined in FromCpp fragment
 
-%typemap(out, fragment="FromCpp") int,
+%typemap(out, fragment="FromCpp") Id,
                                   double,
                                   String
 {
   $result = objectFromCpp($1);
 }
 
-%typemap(out, fragment="FromCpp") int*,    const int*,    int&,    const int&,
+%typemap(out, fragment="FromCpp") Id*,     const Id*,     Id&,     const Id&,
                                   double*, const double*, double&, const double&,
                                   String*, const String*, String&, const String&
 {

--- a/tests/cpp/testArgs.cpp
+++ b/tests/cpp/testArgs.cpp
@@ -14,7 +14,7 @@ int main()
   i = a.testIntRef(22);
   if (i != 22)
     std::cout << "Wrong Int Reference!" << std::endl;
-  const int* pi = a.testIntPtr(new int(32));
+  const Id* pi = a.testIntPtr(new Id(32));
   if ((*pi) != 32)
     std::cout << "Wrong Int Pointer!" << std::endl;
   VectorInt vi = a.testVectorInt({23,33,43});

--- a/tests/r/testArgs.ref
+++ b/tests/r/testArgs.ref
@@ -16,7 +16,7 @@ Test VectorInt: [26 36]
 Test VectorInt Reference: [26 36]
 Test VectorInt Pointer: [26 36]
 Test VectorInt Reference Out: [26 36]
-_p_VectorNumTT_int_t
+_p_VectorNumTT_long_long_t
 Test VectorInt Reference Def: [2 3] - [4 5]
 Test VectorInt Reference Def: [] - [4 5]
 Test VectorInt Reference Def: [] - [4 5]


### PR DESCRIPTION
This PR updates swigex to use a parametrized default integer type, `Id`, similar to gstlearn. This default type is set to `long long`.

Pierre