### PR TITLE
[ci] Update macOS images, retire macos-13

### DIFF
--- a/.github/workflows/coverage-tests_python.yml
+++ b/.github/workflows/coverage-tests_python.yml
@@ -20,7 +20,7 @@ jobs:
         # Double quote for version is needed otherwise 3.10 => 3.1
         python: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         # See the list here: https://github.com/actions/runner-images#available-images
-        os: [ubuntu-22.04, ubuntu-24.04, windows-2022, windows-2025, macos-13, macos-14, macos-15]
+        os: [ubuntu-22.04, ubuntu-24.04, windows-2022, windows-2025, macos-14, macos-15, macos-15-intel, macos-26]
         exclude:
           - os: macos-14
             python: "3.9"

--- a/.github/workflows/coverage-tests_r.yml
+++ b/.github/workflows/coverage-tests_r.yml
@@ -20,14 +20,7 @@ jobs:
         # Last releases from here https://cran.r-project.org/src/base/R-4/
         r_version: [4.2.3, 4.3.3, 4.4.3, 4.5.2]
         # See the list here: https://github.com/actions/runner-images#available-images
-        os: [ubuntu-22.04, ubuntu-24.04, windows-2022, windows-2025, macos-13, macos-14, macos-15]
-        exclude:
-          - os: macos-13
-            r_version: 4.3.3
-          - os: macos-13
-            r_version: 4.4.3
-          - os: macos-13
-            r_version: 4.5.2
+        os: [ubuntu-22.04, ubuntu-24.04, windows-2022, windows-2025, macos-14, macos-15, macos-15-intel, macos-26]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/publish_python_macos.yml
+++ b/.github/workflows/publish_python_macos.yml
@@ -34,7 +34,6 @@ jobs:
         # Python version
         python: [
           # Double quote for version is needed otherwise 3.10 => 3.1
-            {py: "3.9"},
             {py: "3.10"},
             {py: "3.11"},
             {py: "3.12"},
@@ -42,15 +41,11 @@ jobs:
             {py: "3.14"}
           ]
         arch: [
-            {ar: x86_64, os: macos-13, pat: /usr/local},
             {ar: arm64,  os: macos-14, pat: /opt/homebrew},
-            {ar: arm64,  os: macos-15, pat: /opt/homebrew}
+            {ar: arm64,  os: macos-15, pat: /opt/homebrew},
+            {ar: x86_64, os: macos-15-intel, pat: /usr/local},
+            {ar: arm64,  os: macos-26, pat: /opt/homebrew},
           ]
-        exclude:
-          - arch: {os: macos-14}
-            python: {py: "3.9"}
-          - arch: {os: macos-15}
-            python: {py: "3.9"}
 
     steps:
     - uses: actions/checkout@v4
@@ -104,7 +99,6 @@ jobs:
       matrix:
         python: [
         # Double quote for version is needed otherwise 3.10 => 3.1
-            {py: "3.9"},
             {py: "3.10"},
             {py: "3.11"},
             {py: "3.12"},
@@ -112,15 +106,11 @@ jobs:
             {py: "3.14"}
           ]
         arch: [
-            {ar: x86_64, os: macos-13},
             {ar: arm64,  os: macos-14},
-            {ar: arm64,  os: macos-15}
+            {ar: arm64,  os: macos-15},
+            {ar: x86_64, os: macos-15-intel},
+            {ar: arm64,  os: macos-26},
           ]
-        exclude:
-          - arch: {os: macos-14}
-            python: {py: "3.9"}
-          - arch: {os: macos-15}
-            python: {py: "3.9"}
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/publish_r_macos.yml
+++ b/.github/workflows/publish_r_macos.yml
@@ -38,14 +38,11 @@ jobs:
         # Last releases from here https://cran.r-project.org/src/base/R-4/
         r_version: [4.2.3, 4.3.3, 4.4.3, 4.5.2]
         arch: [
-            {ar: x86_64, os: macos-13, pat: /usr/local},
             {ar: arm64,  os: macos-14, pat: /opt/homebrew},
-            {ar: arm64,  os: macos-15, pat: /opt/homebrew}
+            {ar: arm64,  os: macos-15, pat: /opt/homebrew},
+            {ar: x86_64, os: macos-15-intel, pat: /usr/local},
+            {ar: arm64,  os: macos-26, pat: /opt/homebrew},
          ]
-        exclude:
-          - {arch: {os: macos-13}, r_version: 4.3.3}
-          - {arch: {os: macos-13}, r_version: 4.4.3}
-          - {arch: {os: macos-13}, r_version: 4.5.2}
 
     steps:
     - uses: actions/checkout@v4
@@ -62,11 +59,8 @@ jobs:
       with:
         r-version: ${{matrix.r_version}}
 
-    - name: Install R dependencies
-      uses: r-lib/actions/setup-r-dependencies@v2
-      with:
-        packages: roxygen2, pkgbuild
-        install-pandoc: false
+    - name: Install R dependencies (binary)
+      run: Rscript -e "install.packages (c('roxygen2', 'pkgbuild'), type='binary')"
 
     - name: Install the customized SWIG from source
       uses: fabien-ors/install-swig-unix-action@v1
@@ -119,14 +113,11 @@ jobs:
         # Last releases from here https://cran.r-project.org/src/base/R-4/
         r_version: [4.2.3, 4.3.3, 4.4.3, 4.5.2]
         arch: [
-            {ar: x86_64, os: macos-13, pat: /usr/local},
-            {ar: arm64,  os: macos-14, pat: /opt/homebrew},
-            {ar: arm64,  os: macos-15, pat: /opt/homebrew}
+            {ar: arm64,  os: macos-14},
+            {ar: arm64,  os: macos-15},
+            {ar: x86_64, os: macos-15-intel},
+            {ar: arm64,  os: macos-26},
          ]
-        exclude:
-          - {arch: {os: macos-13}, r_version: 4.3.3}
-          - {arch: {os: macos-13}, r_version: 4.4.3}
-          - {arch: {os: macos-13}, r_version: 4.5.2}
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Apply https://github.com/gstlearn/gstlearn/pull/795 on swigex.

Additional change: `setup-r-dependencies` has been switched to `install.packages` since the former did not install `roxygen2`.

Corresponding workflow run: https://github.com/pierre-guillou/swigex/actions/runs/19957949014