### PR TITLE
Fix makefile dep

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,10 +152,10 @@ static shared build_tests doxygen install uninstall: cmake-doxygen
 python_doc: cmake-python-doxygen
 	@cmake --build $(BUILD_DIR) --target python_doc -- $(N_PROC_OPT)
 
-python_build: python_doc
+python_build: cmake-python-doxygen
 	@cmake --build $(BUILD_DIR) --target python_build -- $(N_PROC_OPT)
 
-python_install: python_build
+python_install: cmake-python-doxygen
 	@cmake --build $(BUILD_DIR) --target python_install -- $(N_PROC_OPT)
 
 
@@ -164,10 +164,10 @@ python_install: python_build
 r_doc: cmake-r-doxygen
 	@cmake --build $(BUILD_DIR) --target r_doc -- $(N_PROC_OPT)
 
-r_build: r_doc
+r_build: cmake-r-doxygen
 	@cmake --build $(BUILD_DIR) --target r_build -- $(N_PROC_OPT)
 
-r_install: r_build
+r_install: cmake-r-doxygen
 	@cmake --build $(BUILD_DIR) --target r_install -- $(N_PROC_OPT)
 
 


### PR DESCRIPTION
Targets dependencies in the makefile were redundant with cmake ones now make file dependencies have been deleted.